### PR TITLE
2Hz + new backlight

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -40,6 +40,7 @@ set(SDK_SOURCE_FILES
         "${NRF5_SDK_PATH}/integration/nrfx/legacy/nrf_drv_clock.h"
         "${NRF5_SDK_PATH}/modules/nrfx/drivers/src/nrfx_clock.c"
         "${NRF5_SDK_PATH}/modules/nrfx/drivers/src/nrfx_gpiote.c"
+        "${NRF5_SDK_PATH}/modules/nrfx/drivers/src/nrfx_timer.c"
         "${NRF5_SDK_PATH}/modules/nrfx/soc/nrfx_atomic.c"
         "${NRF5_SDK_PATH}/modules/nrfx/drivers/src/nrfx_saadc.c"
 

--- a/src/components/ble/SimpleWeatherService.cpp
+++ b/src/components/ble/SimpleWeatherService.cpp
@@ -80,7 +80,7 @@ int WeatherCallback(uint16_t /*connHandle*/, uint16_t /*attrHandle*/, struct ble
   return static_cast<Pinetime::Controllers::SimpleWeatherService*>(arg)->OnCommand(ctxt);
 }
 
-SimpleWeatherService::SimpleWeatherService(const DateTime& dateTimeController) : dateTimeController(dateTimeController) {
+SimpleWeatherService::SimpleWeatherService(DateTime& dateTimeController) : dateTimeController(dateTimeController) {
 }
 
 void SimpleWeatherService::Init() {

--- a/src/components/ble/SimpleWeatherService.h
+++ b/src/components/ble/SimpleWeatherService.h
@@ -40,7 +40,7 @@ namespace Pinetime {
 
     class SimpleWeatherService {
     public:
-      explicit SimpleWeatherService(const DateTime& dateTimeController);
+      explicit SimpleWeatherService(DateTime& dateTimeController);
 
       void Init();
 
@@ -136,7 +136,7 @@ namespace Pinetime {
 
       uint16_t eventHandle {};
 
-      const Pinetime::Controllers::DateTime& dateTimeController;
+      Pinetime::Controllers::DateTime& dateTimeController;
 
       std::optional<CurrentWeather> currentWeather;
       std::optional<Forecast> forecast;

--- a/src/components/brightness/BrightnessController.h
+++ b/src/components/brightness/BrightnessController.h
@@ -2,6 +2,10 @@
 
 #include <cstdint>
 
+#include "nrf_ppi.h"
+#include "nrfx_timer.h"
+#include "nrfx_gpiote.h"
+
 namespace Pinetime {
   namespace Controllers {
     class BrightnessController {
@@ -20,9 +24,17 @@ namespace Pinetime {
 
     private:
       Levels level = Levels::High;
-      uint16_t pwmSequence[1] = {10000};
+      static constexpr uint8_t UNSET = UINT8_MAX;
+      uint8_t lastPin = UNSET;
+      nrfx_timer_t timer;
+      // warning: nimble reserves some ppis
+      // https://github.com/InfiniTimeOrg/InfiniTime/blob/034d83fe6baf1ab3875a34f8cee387e24410a824/src/libs/mynewt-nimble/nimble/drivers/nrf52/src/ble_phy.c#L53
+      // spimaster uses ppi 0 for an erratum workaround
+      // channel 1, 2 should be free to use
+      nrf_ppi_channel_t ppi_backlight_on = NRF_PPI_CHANNEL1;
+      nrf_ppi_channel_t ppi_backlight_off = NRF_PPI_CHANNEL2;
 
-      void setPwm(uint16_t val);
+      void applyBrightness(uint16_t val);
     };
   }
 }

--- a/src/components/datetime/DateTimeController.h
+++ b/src/components/datetime/DateTimeController.h
@@ -45,7 +45,7 @@ namespace Pinetime {
        */
       void SetTimeZone(int8_t timezone, int8_t dst);
 
-      void UpdateTime(uint32_t systickCounter);
+      void UpdateTime(uint32_t systickCounter, bool forceUpdate);
 
       uint16_t Year() const {
         return 1900 + localTime.tm_year;
@@ -124,12 +124,10 @@ namespace Pinetime {
       static const char* MonthShortToStringLow(Months month);
       const char* DayOfWeekShortToStringLow() const;
 
-      std::chrono::time_point<std::chrono::system_clock, std::chrono::nanoseconds> CurrentDateTime() const {
-        return currentDateTime;
-      }
+      std::chrono::time_point<std::chrono::system_clock, std::chrono::nanoseconds> CurrentDateTime();
 
-      std::chrono::time_point<std::chrono::system_clock, std::chrono::nanoseconds> UTCDateTime() const {
-        return currentDateTime - std::chrono::seconds((tzOffset + dstOffset) * 15 * 60);
+      std::chrono::time_point<std::chrono::system_clock, std::chrono::nanoseconds> UTCDateTime() {
+        return CurrentDateTime() - std::chrono::seconds((tzOffset + dstOffset) * 15 * 60);
       }
 
       std::chrono::seconds Uptime() const {

--- a/src/components/gfx/Gfx.cpp
+++ b/src/components/gfx/Gfx.cpp
@@ -124,14 +124,6 @@ void Gfx::pixel_draw(uint8_t x, uint8_t y, uint16_t color) {
   lcd.DrawPixel(x, y, color);
 }
 
-void Gfx::Sleep() {
-  lcd.Sleep();
-}
-
-void Gfx::Wakeup() {
-  lcd.Wakeup();
-}
-
 void Gfx::SetBackgroundColor(uint16_t color) {
   for (int i = 0; i < width; i++) {
     buffer[i] = color;

--- a/src/components/gfx/Gfx.h
+++ b/src/components/gfx/Gfx.h
@@ -24,8 +24,6 @@ namespace Pinetime {
       void SetScrollArea(uint16_t topFixedLines, uint16_t scrollLines, uint16_t bottomFixedLines);
       void SetScrollStartLine(uint16_t line);
 
-      void Sleep();
-      void Wakeup();
       bool GetNextBuffer(uint8_t** buffer, size_t& size) override;
       void pixel_draw(uint8_t x, uint8_t y, uint16_t color);
 

--- a/src/displayapp/DisplayApp.h
+++ b/src/displayapp/DisplayApp.h
@@ -139,7 +139,7 @@ namespace Pinetime {
       TickType_t CalculateSleepTime();
       TickType_t alwaysOnTickCount;
       TickType_t alwaysOnStartTime;
-      static constexpr uint32_t alwaysOnRefreshPeriod = 1000 / (40 / 8);
+      static constexpr uint32_t alwaysOnRefreshPeriod = 1000 / 2;
     };
   }
 }

--- a/src/displayapp/DisplayApp.h
+++ b/src/displayapp/DisplayApp.h
@@ -135,6 +135,11 @@ namespace Pinetime {
       Utility::StaticStack<FullRefreshDirections, returnAppStackSize> appStackDirections;
 
       bool isDimmed = false;
+
+      TickType_t CalculateSleepTime();
+      TickType_t alwaysOnTickCount;
+      TickType_t alwaysOnStartTime;
+      static constexpr uint32_t alwaysOnRefreshPeriod = 1000 / (40 / 8);
     };
   }
 }

--- a/src/displayapp/screens/WatchFaceAnalog.h
+++ b/src/displayapp/screens/WatchFaceAnalog.h
@@ -77,7 +77,7 @@ namespace Pinetime {
 
         BatteryIcon batteryIcon;
 
-        const Controllers::DateTime& dateTimeController;
+        Controllers::DateTime& dateTimeController;
         const Controllers::Battery& batteryController;
         const Controllers::Ble& bleController;
         Controllers::NotificationManager& notificationManager;

--- a/src/drivers/SpiMaster.cpp
+++ b/src/drivers/SpiMaster.cpp
@@ -94,32 +94,41 @@ bool SpiMaster::Init() {
   return true;
 }
 
-void SpiMaster::SetupWorkaroundForFtpan58(NRF_SPIM_Type* spim, uint32_t ppi_channel, uint32_t gpiote_channel) {
-  // Create an event when SCK toggles.
-  NRF_GPIOTE->CONFIG[gpiote_channel] = (GPIOTE_CONFIG_MODE_Event << GPIOTE_CONFIG_MODE_Pos) | (spim->PSEL.SCK << GPIOTE_CONFIG_PSEL_Pos) |
-                                       (GPIOTE_CONFIG_POLARITY_Toggle << GPIOTE_CONFIG_POLARITY_Pos);
+void SpiMaster::SetupWorkaroundForErratum58() {
+  nrfx_gpiote_pin_t pin = spiBaseAddress->PSEL.SCK;
+  nrfx_gpiote_in_config_t gpiote_cfg = {.sense = NRF_GPIOTE_POLARITY_TOGGLE, .pull = NRF_GPIO_PIN_NOPULL, .is_watcher = false, .hi_accuracy = true, .skip_gpio_setup = true};
+  if (!workaroundActive) {
+    // Create an event when SCK toggles.
+    APP_ERROR_CHECK(nrfx_gpiote_in_init(pin, &gpiote_cfg, NULL));
+    nrfx_gpiote_in_event_enable(pin, false);
 
-  // Stop the spim instance when SCK toggles.
-  NRF_PPI->CH[ppi_channel].EEP = (uint32_t) &NRF_GPIOTE->EVENTS_IN[gpiote_channel];
-  NRF_PPI->CH[ppi_channel].TEP = (uint32_t) &spim->TASKS_STOP;
-  NRF_PPI->CHENSET = 1U << ppi_channel;
+    // Stop the spim instance when SCK toggles.
+    nrf_ppi_channel_endpoint_setup(workaround_ppi, nrfx_gpiote_in_event_addr_get(pin), spiBaseAddress->TASKS_STOP);
+    nrf_ppi_channel_enable(workaround_ppi);
+  }
+
   spiBaseAddress->EVENTS_END = 0;
 
   // Disable IRQ
-  spim->INTENCLR = (1 << 6);
-  spim->INTENCLR = (1 << 1);
-  spim->INTENCLR = (1 << 19);
+  spiBaseAddress->INTENCLR = (1 << 6);
+  spiBaseAddress->INTENCLR = (1 << 1);
+  spiBaseAddress->INTENCLR = (1 << 19);
+  workaroundActive = true;
 }
 
-void SpiMaster::DisableWorkaroundForFtpan58(NRF_SPIM_Type* spim, uint32_t ppi_channel, uint32_t gpiote_channel) {
-  NRF_GPIOTE->CONFIG[gpiote_channel] = 0;
-  NRF_PPI->CH[ppi_channel].EEP = 0;
-  NRF_PPI->CH[ppi_channel].TEP = 0;
-  NRF_PPI->CHENSET = ppi_channel;
+void SpiMaster::DisableWorkaroundForErratum58() {
+  nrfx_gpiote_pin_t pin = spiBaseAddress->PSEL.SCK;
+  if (workaroundActive) {
+    nrfx_gpiote_in_uninit(pin);
+    nrf_ppi_channel_disable(workaround_ppi);
+  }
   spiBaseAddress->EVENTS_END = 0;
-  spim->INTENSET = (1 << 6);
-  spim->INTENSET = (1 << 1);
-  spim->INTENSET = (1 << 19);
+
+  // Enable IRQ
+  spiBaseAddress->INTENSET = (1 << 6);
+  spiBaseAddress->INTENSET = (1 << 1);
+  spiBaseAddress->INTENSET = (1 << 19);
+  workaroundActive = false;
 }
 
 void SpiMaster::OnEndEvent() {
@@ -183,9 +192,9 @@ bool SpiMaster::Write(uint8_t pinCsn, const uint8_t* data, size_t size) {
   this->pinCsn = pinCsn;
 
   if (size == 1) {
-    SetupWorkaroundForFtpan58(spiBaseAddress, 0, 0);
+    SetupWorkaroundForErratum58();
   } else {
-    DisableWorkaroundForFtpan58(spiBaseAddress, 0, 0);
+    DisableWorkaroundForErratum58();
   }
 
   nrf_gpio_pin_clear(this->pinCsn);
@@ -205,7 +214,7 @@ bool SpiMaster::Write(uint8_t pinCsn, const uint8_t* data, size_t size) {
     nrf_gpio_pin_set(this->pinCsn);
     currentBufferAddr = 0;
 
-    DisableWorkaroundForFtpan58(spiBaseAddress, 0, 0);
+    DisableWorkaroundForErratum58();
 
     xSemaphoreGive(mutex);
   }
@@ -219,7 +228,7 @@ bool SpiMaster::Read(uint8_t pinCsn, uint8_t* cmd, size_t cmdSize, uint8_t* data
   taskToNotify = nullptr;
 
   this->pinCsn = pinCsn;
-  DisableWorkaroundForFtpan58(spiBaseAddress, 0, 0);
+  DisableWorkaroundForErratum58();
   spiBaseAddress->INTENCLR = (1 << 6);
   spiBaseAddress->INTENCLR = (1 << 1);
   spiBaseAddress->INTENCLR = (1 << 19);
@@ -268,7 +277,7 @@ bool SpiMaster::WriteCmdAndBuffer(uint8_t pinCsn, const uint8_t* cmd, size_t cmd
   taskToNotify = nullptr;
 
   this->pinCsn = pinCsn;
-  DisableWorkaroundForFtpan58(spiBaseAddress, 0, 0);
+  DisableWorkaroundForErratum58();
   spiBaseAddress->INTENCLR = (1 << 6);
   spiBaseAddress->INTENCLR = (1 << 1);
   spiBaseAddress->INTENCLR = (1 << 19);

--- a/src/drivers/SpiMaster.h
+++ b/src/drivers/SpiMaster.h
@@ -5,6 +5,8 @@
 #include <FreeRTOS.h>
 #include <semphr.h>
 #include <task.h>
+#include "nrfx_gpiote.h"
+#include "nrf_ppi.h"
 
 namespace Pinetime {
   namespace Drivers {
@@ -43,8 +45,8 @@ namespace Pinetime {
       void Wakeup();
 
     private:
-      void SetupWorkaroundForFtpan58(NRF_SPIM_Type* spim, uint32_t ppi_channel, uint32_t gpiote_channel);
-      void DisableWorkaroundForFtpan58(NRF_SPIM_Type* spim, uint32_t ppi_channel, uint32_t gpiote_channel);
+      void SetupWorkaroundForErratum58();
+      void DisableWorkaroundForErratum58();
       void PrepareTx(const volatile uint32_t bufferAddress, const volatile size_t size);
       void PrepareRx(const volatile uint32_t bufferAddress, const volatile size_t size);
 
@@ -58,6 +60,8 @@ namespace Pinetime {
       volatile size_t currentBufferSize = 0;
       volatile TaskHandle_t taskToNotify;
       SemaphoreHandle_t mutex = nullptr;
+      constexpr static nrf_ppi_channel_t workaround_ppi = NRF_PPI_CHANNEL0;
+      bool workaroundActive = false;
     };
   }
 }

--- a/src/drivers/St7789.cpp
+++ b/src/drivers/St7789.cpp
@@ -25,6 +25,9 @@ void St7789::Init() {
 #ifndef DRIVER_DISPLAY_MIRROR
   DisplayInversionOn();
 #endif
+  PorchSet();
+  FrameRateNormalSet();
+  IdleFrameRateOff();
   NormalModeOn();
   SetVdv();
   PowerControl();
@@ -125,19 +128,35 @@ void St7789::IdleModeOff() {
   vTaskDelay(pdMS_TO_TICKS(10));
 }
 
-void St7789::FrameRateLow() {
-  WriteCommand(static_cast<uint8_t>(Commands::FrameRate));
+void St7789::PorchSet() {
+  WriteCommand(static_cast<uint8_t>(Commands::Porch));
+  WriteData(0x02);
+  WriteData(0x03);
+  WriteData(0x01);
+  WriteData(0xed);
+  WriteData(0xed);
+  vTaskDelay(pdMS_TO_TICKS(300));
+}
+
+void St7789::FrameRateNormalSet() {
+  WriteCommand(static_cast<uint8_t>(Commands::FrameRateNormal));
+  WriteData(0x0a);
+  vTaskDelay(pdMS_TO_TICKS(300));
+}
+
+void St7789::IdleFrameRateOn() {
+  WriteCommand(static_cast<uint8_t>(Commands::FrameRateIdle));
   WriteData(0x13);
   WriteData(0x1e);
   WriteData(0x1e);
   vTaskDelay(pdMS_TO_TICKS(300));
 }
 
-void St7789::FrameRateNormal() {
-  WriteCommand(static_cast<uint8_t>(Commands::FrameRate));
+void St7789::IdleFrameRateOff() {
+  WriteCommand(static_cast<uint8_t>(Commands::FrameRateIdle));
   WriteData(0x00);
-  WriteData(0x0f);
-  WriteData(0x0f);
+  WriteData(0x0a);
+  WriteData(0x0a);
   vTaskDelay(pdMS_TO_TICKS(300));
 }
 
@@ -236,13 +255,13 @@ void St7789::HardwareReset() {
 
 void St7789::LowPowerOn() {
   IdleModeOn();
-  FrameRateLow();
+  IdleFrameRateOn();
   NRF_LOG_INFO("[LCD] Low power mode");
 }
 
 void St7789::LowPowerOff() {
   IdleModeOff();
-  FrameRateNormal();
+  IdleFrameRateOff();
   NRF_LOG_INFO("[LCD] Normal power mode");
 }
 

--- a/src/drivers/St7789.cpp
+++ b/src/drivers/St7789.cpp
@@ -135,13 +135,13 @@ void St7789::PorchSet() {
   WriteData(0x01);
   WriteData(0xed);
   WriteData(0xed);
-  vTaskDelay(pdMS_TO_TICKS(300));
+  vTaskDelay(pdMS_TO_TICKS(10));
 }
 
 void St7789::FrameRateNormalSet() {
   WriteCommand(static_cast<uint8_t>(Commands::FrameRateNormal));
   WriteData(0x0a);
-  vTaskDelay(pdMS_TO_TICKS(300));
+  vTaskDelay(pdMS_TO_TICKS(10));
 }
 
 void St7789::IdleFrameRateOn() {
@@ -149,7 +149,7 @@ void St7789::IdleFrameRateOn() {
   WriteData(0x13);
   WriteData(0x1e);
   WriteData(0x1e);
-  vTaskDelay(pdMS_TO_TICKS(300));
+  vTaskDelay(pdMS_TO_TICKS(10));
 }
 
 void St7789::IdleFrameRateOff() {
@@ -157,7 +157,7 @@ void St7789::IdleFrameRateOff() {
   WriteData(0x00);
   WriteData(0x0a);
   WriteData(0x0a);
-  vTaskDelay(pdMS_TO_TICKS(300));
+  vTaskDelay(pdMS_TO_TICKS(10));
 }
 
 void St7789::DisplayOn() {
@@ -207,7 +207,7 @@ void St7789::SetVdv() {
 
 void St7789::DisplayOff() {
   WriteCommand(static_cast<uint8_t>(Commands::DisplayOff));
-  vTaskDelay(pdMS_TO_TICKS(500));
+  vTaskDelay(pdMS_TO_TICKS(200));
 }
 
 void St7789::VerticalScrollDefinition(uint16_t topFixedLines, uint16_t scrollLines, uint16_t bottomFixedLines) {

--- a/src/drivers/St7789.cpp
+++ b/src/drivers/St7789.cpp
@@ -48,7 +48,7 @@ void St7789::WriteSpi(const uint8_t* data, size_t size) {
 
 void St7789::SoftwareReset() {
   WriteCommand(static_cast<uint8_t>(Commands::SoftwareReset));
-  nrf_delay_ms(150);
+  vTaskDelay(pdMS_TO_TICKS(150));
 }
 
 void St7789::Command2Enable() {
@@ -70,7 +70,7 @@ void St7789::SleepIn() {
 void St7789::ColMod() {
   WriteCommand(static_cast<uint8_t>(Commands::ColMod));
   WriteData(0x55);
-  nrf_delay_ms(10);
+  vTaskDelay(pdMS_TO_TICKS(10));
 }
 
 void St7789::MemoryDataAccessControl() {
@@ -107,22 +107,22 @@ void St7789::RowAddressSet() {
 
 void St7789::DisplayInversionOn() {
   WriteCommand(static_cast<uint8_t>(Commands::DisplayInversionOn));
-  nrf_delay_ms(10);
+  vTaskDelay(pdMS_TO_TICKS(10));
 }
 
 void St7789::NormalModeOn() {
   WriteCommand(static_cast<uint8_t>(Commands::NormalModeOn));
-  nrf_delay_ms(10);
+  vTaskDelay(pdMS_TO_TICKS(10));
 }
 
 void St7789::IdleModeOn() {
   WriteCommand(static_cast<uint8_t>(Commands::IdleModeOn));
-  nrf_delay_ms(10);
+  vTaskDelay(pdMS_TO_TICKS(10));
 }
 
 void St7789::IdleModeOff() {
   WriteCommand(static_cast<uint8_t>(Commands::IdleModeOff));
-  nrf_delay_ms(10);
+  vTaskDelay(pdMS_TO_TICKS(10));
 }
 
 void St7789::FrameRateLow() {
@@ -130,7 +130,7 @@ void St7789::FrameRateLow() {
   WriteData(0x13);
   WriteData(0x1f);
   WriteData(0x1f);
-  nrf_delay_ms(300);
+  vTaskDelay(pdMS_TO_TICKS(300));
 }
 
 void St7789::FrameRateNormal() {
@@ -138,7 +138,7 @@ void St7789::FrameRateNormal() {
   WriteData(0x00);
   WriteData(0x0f);
   WriteData(0x0f);
-  nrf_delay_ms(300);
+  vTaskDelay(pdMS_TO_TICKS(300));
 }
 
 void St7789::DisplayOn() {
@@ -188,7 +188,7 @@ void St7789::SetVdv() {
 
 void St7789::DisplayOff() {
   WriteCommand(static_cast<uint8_t>(Commands::DisplayOff));
-  nrf_delay_ms(500);
+  vTaskDelay(pdMS_TO_TICKS(500));
 }
 
 void St7789::VerticalScrollDefinition(uint16_t topFixedLines, uint16_t scrollLines, uint16_t bottomFixedLines) {
@@ -230,7 +230,7 @@ void St7789::DrawBuffer(uint16_t x, uint16_t y, uint16_t width, uint16_t height,
 
 void St7789::HardwareReset() {
   nrf_gpio_pin_clear(pinReset);
-  nrf_delay_ms(10);
+  vTaskDelay(pdMS_TO_TICKS(10));
   nrf_gpio_pin_set(pinReset);
 }
 

--- a/src/drivers/St7789.cpp
+++ b/src/drivers/St7789.cpp
@@ -128,8 +128,8 @@ void St7789::IdleModeOff() {
 void St7789::FrameRateLow() {
   WriteCommand(static_cast<uint8_t>(Commands::FrameRate));
   WriteData(0x13);
-  WriteData(0x1f);
-  WriteData(0x1f);
+  WriteData(0x1e);
+  WriteData(0x1e);
   vTaskDelay(pdMS_TO_TICKS(300));
 }
 

--- a/src/drivers/St7789.h
+++ b/src/drivers/St7789.h
@@ -45,13 +45,15 @@ namespace Pinetime {
       void NormalModeOn();
       void IdleModeOn();
       void IdleModeOff();
-      void FrameRateNormal();
-      void FrameRateLow();
+      void FrameRateNormalSet();
+      void IdleFrameRateOff();
+      void IdleFrameRateOn();
       void WriteToRam();
       void DisplayOn();
       void DisplayOff();
       void PowerControl();
       void GateControl();
+      void PorchSet();
 
       void SetAddrWindow(uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1);
       void SetVdv();
@@ -75,12 +77,14 @@ namespace Pinetime {
         IdleModeOff = 0x38,
         IdleModeOn = 0x39,
         ColMod = 0x3a,
-        FrameRate = 0xb3,
+        FrameRateIdle = 0xb3,
+        FrameRateNormal = 0xc6,
         VdvSet = 0xc4,
         PowerControl1 = 0xd0,
         Command2Enable = 0xdf,
         PowerControl2 = 0xe8,
         GateControl = 0xb7,
+        Porch = 0xb2,
       };
       void WriteData(uint8_t data);
       void ColumnAddressSet();

--- a/src/sdk_config.h
+++ b/src/sdk_config.h
@@ -4678,7 +4678,7 @@
 // <q> NRFX_TIMER1_ENABLED  - Enable TIMER1 instance
 
 #ifndef NRFX_TIMER1_ENABLED
-  #define NRFX_TIMER1_ENABLED 0
+  #define NRFX_TIMER1_ENABLED 1
 #endif
 
 // <q> NRFX_TIMER2_ENABLED  - Enable TIMER2 instance
@@ -6319,7 +6319,7 @@
 // <e> TIMER_ENABLED - nrf_drv_timer - TIMER periperal driver - legacy layer
 //==========================================================
 #ifndef TIMER_ENABLED
-  #define TIMER_ENABLED 0
+  #define TIMER_ENABLED 1
 #endif
 // <o> TIMER_DEFAULT_CONFIG_FREQUENCY  - Timer frequency if in Timer mode
 
@@ -6383,7 +6383,7 @@
 // <q> TIMER1_ENABLED  - Enable TIMER1 instance
 
 #ifndef TIMER1_ENABLED
-  #define TIMER1_ENABLED 0
+  #define TIMER1_ENABLED 1
 #endif
 
 // <q> TIMER2_ENABLED  - Enable TIMER2 instance

--- a/src/systemtask/SystemTask.cpp
+++ b/src/systemtask/SystemTask.cpp
@@ -102,7 +102,9 @@ void SystemTask::Work() {
   watchdog.Setup(7, Drivers::Watchdog::SleepBehaviour::Run, Drivers::Watchdog::HaltBehaviour::Pause);
   watchdog.Start();
   NRF_LOG_INFO("Last reset reason : %s", Pinetime::Drivers::ResetReasonToString(watchdog.GetResetReason()));
-  APP_GPIOTE_INIT(2);
+  if (!nrfx_gpiote_is_init()) {
+    nrfx_gpiote_init();
+  }
 
   spi.Init();
   spiNorFlash.Init();

--- a/src/systemtask/SystemTask.cpp
+++ b/src/systemtask/SystemTask.cpp
@@ -410,8 +410,6 @@ void SystemTask::Work() {
     }
 
     monitor.Process();
-    uint32_t systick_counter = nrf_rtc_counter_get(portNRF_RTC_REG);
-    dateTimeController.UpdateTime(systick_counter);
     NoInit_BackUpTime = dateTimeController.CurrentDateTime();
     if (nrf_gpio_pin_read(PinMap::Button) == 0) {
       watchdog.Reload();


### PR DESCRIPTION
- Removed some old LCD controls
- Switched delays to yield to RTOS (save CPU time)
- Time locked frame presentation for idle frames
- 2Hz idle / 75Hz on
- Shorter wait time for LCD operations
- Time is updated for every current time call
- Revised erratum 58 workaround
- New backlight